### PR TITLE
Add option to not wrap longitude values

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ These are the available options:
 
 `prefix:` A string to be prepended to the coordinates. Defaults to the empty string ‘’.
 
-`wrapLng:` Controls if longitude values will be wrapped. Defaults to true.
+`wrapLng:` Controls if longitude values will be [wrapped](https://leafletjs.com/reference-1.5.0.html#latlng-wrap). Defaults to true.
 
 ## Public Methods:
 

--- a/README.md
+++ b/README.md
@@ -30,6 +30,8 @@ These are the available options:
 
 `prefix:` A string to be prepended to the coordinates. Defaults to the empty string ‘’.
 
+`wrapLng:` Controls if longitude values will be wrapped. Defaults to true.
+
 ## Public Methods:
 
 These are the available methods:

--- a/src/L.Control.MousePosition.js
+++ b/src/L.Control.MousePosition.js
@@ -10,7 +10,7 @@ L.Control.MousePosition = L.Control.extend({
 		numDigits: 5,
 		lngFormatter: undefined,
 		latFormatter: undefined,
-		prefix: ""
+		prefix: "",
 	},
 
 	onAdd: function (map) {

--- a/src/L.Control.MousePosition.js
+++ b/src/L.Control.MousePosition.js
@@ -31,8 +31,10 @@ L.Control.MousePosition = L.Control.extend({
 
 	_onMouseMove: function (e) {
 		this._pos = e.latlng.wrap();
-		var lng = this.options.lngFormatter ? this.options.lngFormatter(e.latlng.wrap().lng) : L.Util.formatNum(e.latlng.wrap().lng, this.options.numDigits);
-		var lat = this.options.latFormatter ? this.options.latFormatter(e.latlng.lat) : L.Util.formatNum(e.latlng.lat, this.options.numDigits);
+		var lngValue = e.latlng.wrap().lng;
+		var latValue = e.latlng.lat;
+		var lng = this.options.lngFormatter ? this.options.lngFormatter(lngValue) : L.Util.formatNum(lngValue, this.options.numDigits);
+		var lat = this.options.latFormatter ? this.options.latFormatter(latValue) : L.Util.formatNum(latValue, this.options.numDigits);
 		var value = this.options.lngFirst ? lng + this.options.separator + lat : lat + this.options.separator + lng;
 		this._container.innerHTML = this.options.prefix + ' ' + value;
 	}

--- a/src/L.Control.MousePosition.js
+++ b/src/L.Control.MousePosition.js
@@ -11,6 +11,7 @@ L.Control.MousePosition = L.Control.extend({
 		lngFormatter: undefined,
 		latFormatter: undefined,
 		prefix: "",
+		wrapLng: true,
 	},
 
 	onAdd: function (map) {
@@ -31,7 +32,7 @@ L.Control.MousePosition = L.Control.extend({
 
 	_onMouseMove: function (e) {
 		this._pos = e.latlng.wrap();
-		var lngValue = e.latlng.wrap().lng;
+		var lngValue = this.options.wrapLng ? e.latlng.wrap().lng : e.latlng.lng;
 		var latValue = e.latlng.lat;
 		var lng = this.options.lngFormatter ? this.options.lngFormatter(lngValue) : L.Util.formatNum(lngValue, this.options.numDigits);
 		var lat = this.options.latFormatter ? this.options.latFormatter(latValue) : L.Util.formatNum(latValue, this.options.numDigits);


### PR DESCRIPTION
When using Leaflet with a [custom CRS](https://leafletjs.com/examples/crs-simple/crs-simple.html) for a map that is not the earth globe (e.g. a game or similar), the default wrapping destroys the values.
