### PR TITLE
Add formatting function that formats both lat and long at the same time

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,3 +29,5 @@ These are the available options:
 `latFormatter:` Custom function to format the latitude value. Defaults to undefined
 
 `prefix:` A string to be prepended to the coordinates. Defaults to the empty string ‘’.
+
+`formatter:` A custom function to format the entire value. If used will ignore: `lngFirst`, `lngFormatter`, `latFormatter`, `prefix`

--- a/README.md
+++ b/README.md
@@ -26,15 +26,16 @@ These are the available options:
 
 `lngFirst:` Weather to put the longitude first or not. Defaults to false
 
-`lngFormatter:` Custom function to format the longitude value. Defaults to undefined
+`lngFormatter:` Custom function to format the longitude value. Argument: numerical longitude value. Return value: formatted string. Defaults to undefined.
 
-`latFormatter:` Custom function to format the latitude value. Defaults to undefined
+`latFormatter:` Custom function to format the latitude value. Argument: numerical latitude value. Return value: formatted string. Defaults to undefined.
 
 `prefix:` A string to be prepended to the coordinates. Defaults to the empty string ‘’.
 
 `wrapLng:` Controls if longitude values will be [wrapped](https://leafletjs.com/reference-1.5.0.html#latlng-wrap). Defaults to true.
 
-`formatter:` A custom function to format the entire value. If used will ignore: `lngFirst`, `lngFormatter`, `latFormatter`, `prefix`
+`formatter:` A custom function to format the entire value. Arguments: numerical longitude value, numerical latitude value. Return value: formatted string.
+ Defaults to undefined. If defined will ignore: `lngFirst`, `lngFormatter`, `latFormatter` and `prefix`.
 
 ## Public Methods:
 

--- a/src/L.Control.MousePosition.js
+++ b/src/L.Control.MousePosition.js
@@ -7,6 +7,7 @@ L.Control.MousePosition = L.Control.extend({
     numDigits: 5,
     lngFormatter: undefined,
     latFormatter: undefined,
+    formatter: undefined,
     prefix: ""
   },
 
@@ -23,10 +24,19 @@ L.Control.MousePosition = L.Control.extend({
   },
 
   _onMouseMove: function (e) {
-    var lng = this.options.lngFormatter ? this.options.lngFormatter(e.latlng.lng) : L.Util.formatNum(e.latlng.lng, this.options.numDigits);
-    var lat = this.options.latFormatter ? this.options.latFormatter(e.latlng.lat) : L.Util.formatNum(e.latlng.lat, this.options.numDigits);
-    var value = this.options.lngFirst ? lng + this.options.separator + lat : lat + this.options.separator + lng;
-    var prefixAndValue = this.options.prefix + ' ' + value;
+    var lng;
+    var lat;
+    var value;
+    var prefixAndValue;
+    if (this.options.formatter) {
+        prefixAndValue = this.options.formatter(e.latlng.lng, e.latlng.lat);
+    } else {
+        lng = this.options.lngFormatter ? this.options.lngFormatter(e.latlng.lng) : L.Util.formatNum(e.latlng.lng, this.options.numDigits);
+        lat = this.options.latFormatter ? this.options.latFormatter(e.latlng.lat) : L.Util.formatNum(e.latlng.lat, this.options.numDigits);
+        value = this.options.lngFirst ? lng + this.options.separator + lat : lat + this.options.separator + lng;
+        prefixAndValue = this.options.prefix + ' ' + value;
+    }
+
     this._container.innerHTML = prefixAndValue;
   }
 

--- a/src/L.Control.MousePosition.js
+++ b/src/L.Control.MousePosition.js
@@ -34,10 +34,17 @@ L.Control.MousePosition = L.Control.extend({
 		this._pos = e.latlng.wrap();
 		var lngValue = this.options.wrapLng ? e.latlng.wrap().lng : e.latlng.lng;
 		var latValue = e.latlng.lat;
-		var lng = this.options.lngFormatter ? this.options.lngFormatter(lngValue) : L.Util.formatNum(lngValue, this.options.numDigits);
-		var lat = this.options.latFormatter ? this.options.latFormatter(latValue) : L.Util.formatNum(latValue, this.options.numDigits);
-		var value = this.options.lngFirst ? lng + this.options.separator + lat : lat + this.options.separator + lng;
-		this._container.innerHTML = this.options.prefix + ' ' + value;
+		var lng;
+		var lat;
+		var value;
+		var prefixAndValue;
+
+		lng = this.options.lngFormatter ? this.options.lngFormatter(lngValue) : L.Util.formatNum(lngValue, this.options.numDigits);
+		lat = this.options.latFormatter ? this.options.latFormatter(latValue) : L.Util.formatNum(latValue, this.options.numDigits);
+		value = this.options.lngFirst ? lng + this.options.separator + lat : lat + this.options.separator + lng;
+		prefixAndValue = this.options.prefix + ' ' + value;
+
+		this._container.innerHTML = prefixAndValue;
 	}
 
 });


### PR DESCRIPTION
For my usecase `latFormatter` and `lngFormatter` are not sufficient because I need both lat and long values as input to do some matrix transformation in order to calculate the X and Y values to display.

And looking at the different forks, several of them already have added this ([latLngFormatter](https://github.com/tstibbs/Leaflet.MousePosition/commit/b628c7be754c134c63117b3feb75e720a1d20673), [latlonFormatter](https://github.com/birdage/Leaflet.MousePosition/commit/8ae429d8f2069a2c4808e0f2a162de87f7879932), [formatters](https://github.com/nreese/Leaflet.MousePosition/commit/7c8b8b31feffb277ecf1aa6fa4cbad16d233d44a) and [formatter](https://github.com/obama/Leaflet.MousePosition/commit/715008badfcf626bc4f6a62c9ca19a2c53389c29)), so this is a commonly wished feature.

This is a merge of the `formatter` version together with some documentation update.
