### PR TITLE
Update L.Control.MousePosition.js

### DIFF
--- a/src/L.Control.MousePosition.js
+++ b/src/L.Control.MousePosition.js
@@ -24,7 +24,7 @@ L.Control.MousePosition = L.Control.extend({
 	},
 
 	onRemove: function (map) {
-		map.off('mousemove', this._onMouseMove)
+		map.off('mousemove', this._onMouseMove, this)
 	},
 
 	getLatLng: function() {


### PR DESCRIPTION
The onRemove is failing to remove the _onMouseMove event because the context is missing. In Leaflet 1.8.0 it logs the following warning: listener not found. The fix is to include the context (this) in the onRemove function.